### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,3 +220,23 @@ compileTestKotlin {
         jvmTarget = "1.8"
     }
 }
+
+allprojects {
+    tasks.withType(Test).configureEach {
+        maxParallelForks = 4
+    }
+
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
+    tasks.withType(Test).configureEach {
+        reports.html.required = false
+        reports.junitXml.required = false
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.incremental = true
+    }
+
+}


### PR DESCRIPTION

[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution), running multiple test cases in parallel is useful and helpful when there are several CPU cores.

According to [Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options), Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones.
one option is to fork a new test VM after a certain number of tests have run. So our recommendation is to configure "forkEvery" and we give a specific value of 100

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation), Gradle will automatically create test reports by default which will slowing down the overall build. So it's better to disable the test reports while we don't need it

[Incremental compilation](https://docs.gradle.org/current/userguide/performance.html#incremental_compilation), We note that the gradle version for this project is smaller than 4.10, so we recommend enabling this configuration to shorten build times

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
